### PR TITLE
[feat] 퀴즈 단일 조회 기능

### DIFF
--- a/src/main/java/mangmae/harpseal/domain/app/QuizFacadeService.java
+++ b/src/main/java/mangmae/harpseal/domain/app/QuizFacadeService.java
@@ -7,7 +7,7 @@ import mangmae.harpseal.domain.attachment.AttachmentService;
 import mangmae.harpseal.domain.choice.ChoiceService;
 import mangmae.harpseal.domain.choice.dto.ChoiceServiceDto;
 import mangmae.harpseal.domain.question.QuestionService;
-import mangmae.harpseal.domain.question.QuestionCreateServiceDto;
+import mangmae.harpseal.domain.question.dto.QuestionCreateServiceDto;
 import mangmae.harpseal.domain.quiz.service.QuizService;
 import mangmae.harpseal.domain.quiz.service.dto.QuizCreateServiceDto;
 import mangmae.harpseal.domain.quiz.util.QuestionValidator;

--- a/src/main/java/mangmae/harpseal/domain/choice/ChoiceService.java
+++ b/src/main/java/mangmae/harpseal/domain/choice/ChoiceService.java
@@ -3,7 +3,7 @@ package mangmae.harpseal.domain.choice;
 
 import lombok.RequiredArgsConstructor;
 import mangmae.harpseal.domain.choice.dto.ChoiceServiceDto;
-import mangmae.harpseal.domain.question.QuestionCreateServiceDto;
+import mangmae.harpseal.domain.question.dto.QuestionCreateServiceDto;
 import mangmae.harpseal.entity.MultipleQuestionChoice;
 import mangmae.harpseal.entity.Question;
 import org.springframework.stereotype.Service;

--- a/src/main/java/mangmae/harpseal/domain/choice/dto/ChoiceCreateDto.java
+++ b/src/main/java/mangmae/harpseal/domain/choice/dto/ChoiceCreateDto.java
@@ -12,8 +12,6 @@ public class ChoiceCreateDto {
     private String content;
 
     public ChoiceServiceDto toServiceDto() {
-        return ChoiceServiceDto.builder()
-            .content(content)
-            .build();
+        return new ChoiceServiceDto(content);
     }
 }

--- a/src/main/java/mangmae/harpseal/domain/choice/dto/ChoiceRepositoryDto.java
+++ b/src/main/java/mangmae/harpseal/domain/choice/dto/ChoiceRepositoryDto.java
@@ -1,0 +1,13 @@
+package mangmae.harpseal.domain.choice.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChoiceRepositoryDto {
+    private String content;
+}

--- a/src/main/java/mangmae/harpseal/domain/choice/dto/ChoiceServiceDto.java
+++ b/src/main/java/mangmae/harpseal/domain/choice/dto/ChoiceServiceDto.java
@@ -2,10 +2,13 @@ package mangmae.harpseal.domain.choice.dto;
 
 import lombok.*;
 
-@Builder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChoiceServiceDto {
     private String content;
+
+    public static ChoiceServiceDto fromRepositoryDto(ChoiceRepositoryDto dto) {
+        return new ChoiceServiceDto(dto.getContent());
+    }
 }

--- a/src/main/java/mangmae/harpseal/domain/question/dto/QuestionCreateServiceDto.java
+++ b/src/main/java/mangmae/harpseal/domain/question/dto/QuestionCreateServiceDto.java
@@ -1,4 +1,4 @@
-package mangmae.harpseal.domain.question;
+package mangmae.harpseal.domain.question.dto;
 
 
 import lombok.Builder;

--- a/src/main/java/mangmae/harpseal/domain/question/dto/QuestionRepositoryDto.java
+++ b/src/main/java/mangmae/harpseal/domain/question/dto/QuestionRepositoryDto.java
@@ -1,0 +1,40 @@
+package mangmae.harpseal.domain.question.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mangmae.harpseal.domain.choice.dto.ChoiceRepositoryDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionRepositoryDto {
+
+    private String id;
+    private String content;
+    private int number;
+    private String answer;
+    private String type;
+    private String attachmentPath;
+    private List<ChoiceRepositoryDto> choices = new ArrayList<>();
+
+    public QuestionRepositoryDto(
+            String id,
+            String content,
+            int number,
+            String answer
+    ) {
+        this.id = id;
+        this.content = content;
+        this.number = number;
+        this.answer = answer;
+    }
+
+    public void addChoice(ChoiceRepositoryDto dto) {
+        choices.add(dto);
+    }
+}

--- a/src/main/java/mangmae/harpseal/domain/question/dto/QuestionRepositoryDto.java
+++ b/src/main/java/mangmae/harpseal/domain/question/dto/QuestionRepositoryDto.java
@@ -1,40 +1,46 @@
 package mangmae.harpseal.domain.question.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mangmae.harpseal.domain.choice.dto.ChoiceRepositoryDto;
+import mangmae.harpseal.entity.type.QuestionType;
 
 import java.util.ArrayList;
 import java.util.List;
 
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class QuestionRepositoryDto {
 
-    private String id;
+    private Long id;
     private String content;
-    private int number;
+    private Integer number;
     private String answer;
-    private String type;
+    private QuestionType type;
     private String attachmentPath;
     private List<ChoiceRepositoryDto> choices = new ArrayList<>();
 
     public QuestionRepositoryDto(
-            String id,
+            Long id,
             String content,
-            int number,
-            String answer
+            Integer number,
+            String answer,
+            QuestionType type,
+            String attachmentPath
     ) {
         this.id = id;
         this.content = content;
         this.number = number;
         this.answer = answer;
+        this.type = type;
     }
 
-    public void addChoice(ChoiceRepositoryDto dto) {
-        choices.add(dto);
+    public void fetchChoices(List<ChoiceRepositoryDto> dto) {
+        choices = dto;
     }
 }

--- a/src/main/java/mangmae/harpseal/domain/question/dto/QuestionServiceDto.java
+++ b/src/main/java/mangmae/harpseal/domain/question/dto/QuestionServiceDto.java
@@ -1,0 +1,25 @@
+package mangmae.harpseal.domain.question.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mangmae.harpseal.domain.choice.dto.ChoiceServiceDto;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionServiceDto {
+
+    private String content;
+    private int number;
+    private String answer;
+    private String type;
+    private String attachmentData;
+    List<ChoiceServiceDto> choices;
+
+}

--- a/src/main/java/mangmae/harpseal/domain/question/dto/QuestionServiceDto.java
+++ b/src/main/java/mangmae/harpseal/domain/question/dto/QuestionServiceDto.java
@@ -22,4 +22,20 @@ public class QuestionServiceDto {
     private String attachmentData;
     List<ChoiceServiceDto> choices;
 
+    public static QuestionServiceDto fromRepositoryDto(
+            final QuestionRepositoryDto dto,
+            final String data,
+            final List<ChoiceServiceDto> choices) {
+
+        return QuestionServiceDto.builder()
+                .content(dto.getContent())
+                .number(dto.getNumber())
+                .answer(dto.getAnswer())
+                .type(dto.getType().toString())
+                .attachmentData(data)
+                .choices(choices)
+                .build();
+
+    }
+
 }

--- a/src/main/java/mangmae/harpseal/domain/quiz/controller/QuizController.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/controller/QuizController.java
@@ -8,6 +8,8 @@ import mangmae.harpseal.domain.quiz.dto.request.QuizCreateRequestForm;
 import mangmae.harpseal.domain.quiz.controller.dto.QuizSearchRequestCond;
 import mangmae.harpseal.domain.quiz.service.QuizService;
 import mangmae.harpseal.domain.quiz.service.dto.QuizSearchServiceDto;
+import mangmae.harpseal.domain.quiz.service.dto.SingleQuizServiceCond;
+import mangmae.harpseal.domain.quiz.service.dto.SingleQuizServiceResponse;
 import mangmae.harpseal.entity.Quiz;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -44,6 +46,11 @@ public class QuizController {
         return quizService.searchWithCondition(condition.toServiceDto(), pageable);
     }
 
+    @GetMapping("/{quizId}")
+    public SingleQuizServiceResponse findSingleQuiz(@PathVariable("quizId") Long quizId) {
+        return quizService.findSingleQuiz(new SingleQuizServiceCond(quizId));
+    }
+
     @PostMapping(value = "/new", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<String> createQuiz(
             @RequestPart(value = "form") QuizCreateRequestForm form,
@@ -52,6 +59,7 @@ public class QuizController {
         Quiz createdQuiz = quizFacadeService.createQuiz(form.toServiceDto(), thumbnail);
         return ResponseEntity.created(URI.create("/quiz/api/v1/" + createdQuiz.getId())).build();
     }
+
 
 
 }

--- a/src/main/java/mangmae/harpseal/domain/quiz/dto/request/QuestionCreateRequestForm.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/dto/request/QuestionCreateRequestForm.java
@@ -3,7 +3,7 @@ package mangmae.harpseal.domain.quiz.dto.request;
 import lombok.*;
 import mangmae.harpseal.domain.choice.dto.ChoiceCreateDto;
 import mangmae.harpseal.domain.choice.dto.ChoiceServiceDto;
-import mangmae.harpseal.domain.question.QuestionCreateServiceDto;
+import mangmae.harpseal.domain.question.dto.QuestionCreateServiceDto;
 
 import java.util.List;
 

--- a/src/main/java/mangmae/harpseal/domain/quiz/repository/QuizQueryRepository.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/repository/QuizQueryRepository.java
@@ -2,6 +2,7 @@ package mangmae.harpseal.domain.quiz.repository;
 
 import mangmae.harpseal.domain.quiz.repository.dto.QuizSearchRepositoryCond;
 import mangmae.harpseal.domain.quiz.repository.dto.QuizSearchRepositoryDto;
+import mangmae.harpseal.domain.quiz.repository.dto.SingleQuizRepositoryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -16,5 +17,7 @@ public interface QuizQueryRepository {
     public Page<QuizSearchRepositoryDto> findRecentDesc(QuizSearchRepositoryCond condition, Pageable pageable);
 
     public Page<QuizSearchRepositoryDto> findRecentAsc(QuizSearchRepositoryCond condition, Pageable pageable);
+
+    public SingleQuizRepositoryResponse findSingleQuizById(Long quizId);
 
 }

--- a/src/main/java/mangmae/harpseal/domain/quiz/repository/QuizRepositoryImpl.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/repository/QuizRepositoryImpl.java
@@ -3,10 +3,10 @@ package mangmae.harpseal.domain.quiz.repository;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import lombok.extern.slf4j.Slf4j;
 import mangmae.harpseal.domain.choice.dto.ChoiceRepositoryDto;
 import mangmae.harpseal.domain.question.dto.QuestionRepositoryDto;
 import mangmae.harpseal.domain.quiz.repository.dto.QuizSearchRepositoryCond;
@@ -19,7 +19,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static mangmae.harpseal.entity.QAttachment.*;
@@ -29,6 +28,7 @@ import static mangmae.harpseal.entity.QQuiz.*;
 import static mangmae.harpseal.entity.QQuizThumbnail.*;
 
 
+@Slf4j
 @Repository
 public class QuizRepositoryImpl implements QuizQueryRepository {
 
@@ -203,11 +203,7 @@ public class QuizRepositoryImpl implements QuizQueryRepository {
     @Override
     public SingleQuizRepositoryResponse findSingleQuizById(Long quizId) {
 
-        // 1. quizId 에 해당하는 Question 엔티티를 찾는다.
-        // 2. Question id를 사용해서 Choice를 찾는다.
-        // 3. Choice DTO들을 Question DTO에 추가한다.
-        // 4. Quiz를 찾는다.
-        // 5. 받아온 Quiz DTO에 Question, Choice 정보를 추가한다.
+        long startTime = System.currentTimeMillis();
 
         Quiz findQuiz = em.find(Quiz.class, quizId);
 
@@ -252,15 +248,18 @@ public class QuizRepositoryImpl implements QuizQueryRepository {
                 .fetchOne();
 
 
+        long time = System.currentTimeMillis() - startTime;
+        log.info("time={}ms", time);
+
         return SingleQuizRepositoryResponse.builder()
                 .id(quizId)
                 .title(findQuiz.getTitle())
                 .description(findQuiz.getDescription())
-                .thumbnailFilePath(thumbnailImagePath)
+                .thumbnailPath(thumbnailImagePath)
                 .questions(questionDtoList)
                 .build();
     }
-    
+
     private BooleanExpression quizTitleContains(String quizTitle) {
         return StringUtils.hasText(quizTitle) ? quiz.title.contains(quizTitle) : null;
     }

--- a/src/main/java/mangmae/harpseal/domain/quiz/repository/QuizRepositoryImpl.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/repository/QuizRepositoryImpl.java
@@ -3,24 +3,37 @@ package mangmae.harpseal.domain.quiz.repository;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import mangmae.harpseal.domain.choice.dto.ChoiceRepositoryDto;
+import mangmae.harpseal.domain.question.dto.QuestionRepositoryDto;
 import mangmae.harpseal.domain.quiz.repository.dto.QuizSearchRepositoryCond;
 import mangmae.harpseal.domain.quiz.repository.dto.QuizSearchRepositoryDto;
+import mangmae.harpseal.domain.quiz.repository.dto.SingleQuizRepositoryResponse;
+import mangmae.harpseal.entity.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import static mangmae.harpseal.entity.QAttachment.*;
+import static mangmae.harpseal.entity.QMultipleQuestionChoice.*;
+import static mangmae.harpseal.entity.QQuestion.*;
 import static mangmae.harpseal.entity.QQuiz.*;
 import static mangmae.harpseal.entity.QQuizThumbnail.*;
 
 
 @Repository
 public class QuizRepositoryImpl implements QuizQueryRepository {
+
+    @PersistenceContext
+    EntityManager em;
 
     private final JPAQueryFactory queryFactory;
 
@@ -182,6 +195,72 @@ public class QuizRepositoryImpl implements QuizQueryRepository {
         return new PageImpl<>(result, pageable, total);
     }
 
+    /**
+     * 퀴즈 정보, 퀴즈에 담긴 문제, 문제의 첨부파일, 문제의 선지정보를 담아 반환한다.
+     * @param quizId 반환 받고자 하는 퀴즈 ID
+     * @return 퀴즈 정보를 담은 레포지토리 계층 DTO
+     */
+    @Override
+    public SingleQuizRepositoryResponse findSingleQuizById(Long quizId) {
+
+        // 1. quizId 에 해당하는 Question 엔티티를 찾는다.
+        // 2. Question id를 사용해서 Choice를 찾는다.
+        // 3. Choice DTO들을 Question DTO에 추가한다.
+        // 4. Quiz를 찾는다.
+        // 5. 받아온 Quiz DTO에 Question, Choice 정보를 추가한다.
+
+        Quiz findQuiz = em.find(Quiz.class, quizId);
+
+        List<QuestionRepositoryDto> questionDtoList = queryFactory
+                .select(
+                        Projections.constructor(
+                                QuestionRepositoryDto.class,
+                                question.id,
+                                question.content,
+                                question.number,
+                                question.answer,
+                                question.questionType,
+                                attachment.filePath.as("attachmentPath")
+                        )
+                )
+                .from(question)
+                .leftJoin(question.attachment, attachment)
+                .where(question.quiz.id.eq(quizId))
+                .orderBy(question.number.asc())
+                .fetch();
+
+        questionDtoList
+                .forEach(dto -> {
+                    Long questionId = dto.getId();
+                    List<ChoiceRepositoryDto> choiceResult = queryFactory
+                            .select(
+                                    Projections.constructor(
+                                            ChoiceRepositoryDto.class,
+                                            multipleQuestionChoice.content
+                                    )
+                            )
+                            .from(multipleQuestionChoice)
+                            .where(multipleQuestionChoice.question.id.eq(questionId))
+                            .fetch();
+                    dto.fetchChoices(choiceResult);
+                });
+
+        String thumbnailImagePath = queryFactory
+                .select(quizThumbnail.filePath)
+                .from(quizThumbnail)
+                .where(quizThumbnail.quiz.id.eq(quizId))
+                .fetchOne();
+
+
+        return SingleQuizRepositoryResponse.builder()
+                .id(quizId)
+                .title(findQuiz.getTitle())
+                .description(findQuiz.getDescription())
+                .thumbnailFilePath(thumbnailImagePath)
+                .questions(questionDtoList)
+                .build();
+    }
+    
     private BooleanExpression quizTitleContains(String quizTitle) {
         return StringUtils.hasText(quizTitle) ? quiz.title.contains(quizTitle) : null;
     }

--- a/src/main/java/mangmae/harpseal/domain/quiz/repository/dto/SingleQuizRepositoryCond.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/repository/dto/SingleQuizRepositoryCond.java
@@ -1,0 +1,12 @@
+package mangmae.harpseal.domain.quiz.repository.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SingleQuizRepositoryCond {
+    private String id; // quiz id
+}

--- a/src/main/java/mangmae/harpseal/domain/quiz/repository/dto/SingleQuizRepositoryResponse.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/repository/dto/SingleQuizRepositoryResponse.java
@@ -2,6 +2,7 @@ package mangmae.harpseal.domain.quiz.repository.dto;
 
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mangmae.harpseal.domain.question.dto.QuestionRepositoryDto;
@@ -10,26 +11,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class SingleQuizRepositoryResponse {
-    private String id;
+    private Long id;
     private String title;
     private String description;
     private String thumbnailFilePath;
     private List<QuestionRepositoryDto> questions = new ArrayList<>();
-
-    public SingleQuizRepositoryResponse(
-            final String id,
-            final String title,
-            final String description,
-            final String thumbnailFilePath
-    ) {
-        this.id = id;
-        this.title = title;
-        this.description = description;
-        this.thumbnailFilePath = thumbnailFilePath;
-    }
 
     public void addQuestion(QuestionRepositoryDto dto) {
         questions.add(dto);

--- a/src/main/java/mangmae/harpseal/domain/quiz/repository/dto/SingleQuizRepositoryResponse.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/repository/dto/SingleQuizRepositoryResponse.java
@@ -1,0 +1,37 @@
+package mangmae.harpseal.domain.quiz.repository.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mangmae.harpseal.domain.question.dto.QuestionRepositoryDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SingleQuizRepositoryResponse {
+    private String id;
+    private String title;
+    private String description;
+    private String thumbnailFilePath;
+    private List<QuestionRepositoryDto> questions = new ArrayList<>();
+
+    public SingleQuizRepositoryResponse(
+            final String id,
+            final String title,
+            final String description,
+            final String thumbnailFilePath
+    ) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.thumbnailFilePath = thumbnailFilePath;
+    }
+
+    public void addQuestion(QuestionRepositoryDto dto) {
+        questions.add(dto);
+    }
+}

--- a/src/main/java/mangmae/harpseal/domain/quiz/repository/dto/SingleQuizRepositoryResponse.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/repository/dto/SingleQuizRepositoryResponse.java
@@ -18,7 +18,7 @@ public class SingleQuizRepositoryResponse {
     private Long id;
     private String title;
     private String description;
-    private String thumbnailFilePath;
+    private String thumbnailPath;
     private List<QuestionRepositoryDto> questions = new ArrayList<>();
 
     public void addQuestion(QuestionRepositoryDto dto) {

--- a/src/main/java/mangmae/harpseal/domain/quiz/service/dto/SingleQuizServiceCond.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/service/dto/SingleQuizServiceCond.java
@@ -1,0 +1,13 @@
+package mangmae.harpseal.domain.quiz.service.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SingleQuizServiceCond {
+    private String id; // quiz id
+}

--- a/src/main/java/mangmae/harpseal/domain/quiz/service/dto/SingleQuizServiceCond.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/service/dto/SingleQuizServiceCond.java
@@ -9,5 +9,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SingleQuizServiceCond {
-    private String id; // quiz id
+    private Long id; // quiz id
 }

--- a/src/main/java/mangmae/harpseal/domain/quiz/service/dto/SingleQuizServiceResponse.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/service/dto/SingleQuizServiceResponse.java
@@ -1,0 +1,25 @@
+package mangmae.harpseal.domain.quiz.service.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mangmae.harpseal.domain.question.dto.QuestionServiceDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SingleQuizServiceResponse {
+
+    private String quizId;
+    private String title;
+    private String description;
+    private String thumbnailData;
+    private List<QuestionServiceDto> questions = new ArrayList<>();
+
+}

--- a/src/main/java/mangmae/harpseal/domain/quiz/service/dto/SingleQuizServiceResponse.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/service/dto/SingleQuizServiceResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mangmae.harpseal.domain.question.dto.QuestionServiceDto;
+import mangmae.harpseal.domain.quiz.repository.dto.SingleQuizRepositoryResponse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,10 +17,24 @@ import java.util.List;
 @AllArgsConstructor
 public class SingleQuizServiceResponse {
 
-    private String quizId;
+    private Long quizId;
     private String title;
     private String description;
     private String thumbnailData;
     private List<QuestionServiceDto> questions = new ArrayList<>();
+
+    public static SingleQuizServiceResponse fromRepositoryResponse(
+            final SingleQuizRepositoryResponse dto,
+            final String thumbnailData,
+            final List<QuestionServiceDto> questions
+    ) {
+        return SingleQuizServiceResponse.builder()
+                .quizId(dto.getId())
+                .title(dto.getTitle())
+                .description(dto.getDescription())
+                .thumbnailData(thumbnailData)
+                .questions(questions)
+                .build();
+    }
 
 }

--- a/src/main/java/mangmae/harpseal/domain/quiz/util/QuestionValidator.java
+++ b/src/main/java/mangmae/harpseal/domain/quiz/util/QuestionValidator.java
@@ -1,6 +1,6 @@
 package mangmae.harpseal.domain.quiz.util;
 
-import mangmae.harpseal.domain.question.QuestionCreateServiceDto;
+import mangmae.harpseal.domain.question.dto.QuestionCreateServiceDto;
 import mangmae.harpseal.domain.exception.QuestionFormNotValidException;
 import mangmae.harpseal.entity.type.QuestionType;
 import org.springframework.util.StringUtils;

--- a/src/main/java/mangmae/harpseal/entity/Question.java
+++ b/src/main/java/mangmae/harpseal/entity/Question.java
@@ -4,7 +4,10 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mangmae.harpseal.domain.choice.dto.ChoiceRepositoryDto;
 import mangmae.harpseal.domain.question.dto.QuestionCreateServiceDto;
+import mangmae.harpseal.domain.question.dto.QuestionRepositoryDto;
+import mangmae.harpseal.domain.quiz.repository.dto.QuizSearchRepositoryDto;
 import mangmae.harpseal.entity.type.QuestionType;
 
 import java.util.ArrayList;
@@ -65,6 +68,18 @@ public class Question {
     public void addAttachment(Attachment attachment) {
         this.attachment = attachment;
         attachment.changeQuestion(this);
+    }
+
+    public QuestionRepositoryDto toRepositoryDto(String attachmentPath, List<ChoiceRepositoryDto> choices) {
+        return QuestionRepositoryDto.builder()
+                .id(id)
+                .content(content)
+                .number(number)
+                .answer(answer)
+                .type(questionType)
+                .attachmentPath(attachmentPath)
+                .choices(choices)
+                .build();
     }
 
 }

--- a/src/main/java/mangmae/harpseal/entity/Question.java
+++ b/src/main/java/mangmae/harpseal/entity/Question.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import mangmae.harpseal.domain.question.QuestionCreateServiceDto;
+import mangmae.harpseal.domain.question.dto.QuestionCreateServiceDto;
 import mangmae.harpseal.entity.type.QuestionType;
 
 import java.util.ArrayList;

--- a/src/test/java/mangmae/harpseal/domain/quiz/repository/QuizRepositoryImplTest.java
+++ b/src/test/java/mangmae/harpseal/domain/quiz/repository/QuizRepositoryImplTest.java
@@ -7,6 +7,7 @@ import jakarta.persistence.PersistenceContext;
 import lombok.extern.slf4j.Slf4j;
 import mangmae.harpseal.domain.quiz.repository.dto.QuizSearchRepositoryCond;
 import mangmae.harpseal.domain.quiz.repository.dto.QuizSearchRepositoryDto;
+import mangmae.harpseal.domain.quiz.repository.dto.SingleQuizRepositoryResponse;
 import mangmae.harpseal.entity.Quiz;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -104,6 +105,14 @@ class QuizRepositoryImplTest {
         assertThat(recentAsc.getContent())
                 .extracting("title")
                 .containsExactly(PREFIX + "quiz1", PREFIX + "quiz2", PREFIX + "quiz3", PREFIX + "quiz4");
+
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("퀴즈 ID로 퀴즈 하나 찾기")
+    public void findSingleQuizTest() {
+        SingleQuizRepositoryResponse findQuiz = quizRepositoryImpl.findSingleQuizById(1L);
 
     }
 

--- a/src/test/java/mangmae/harpseal/domain/quiz/repository/QuizRepositoryImplTest.java
+++ b/src/test/java/mangmae/harpseal/domain/quiz/repository/QuizRepositoryImplTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -68,15 +70,16 @@ class QuizRepositoryImplTest {
     public void playTimeSearchTest(){
         //given
         QuizSearchRepositoryCond condition = new QuizSearchRepositoryCond(PREFIX);
+        PageRequest pageRequest = PageRequest.of(0, 4);
         //when
-        List<QuizSearchRepositoryDto> playTimeDesc = quizRepositoryImpl.findPlayTimeDesc(condition, 0, 4);
-        List<QuizSearchRepositoryDto> playTimeAsc = quizRepositoryImpl.findPlayTimeAsc(condition, 0, 4);
+        Page<QuizSearchRepositoryDto> playTimeDesc = quizRepositoryImpl.findPlayTimeDesc(condition, pageRequest);
+        Page<QuizSearchRepositoryDto> playTimeAsc = quizRepositoryImpl.findPlayTimeAsc(condition, pageRequest);
 
         //then
-        assertThat(playTimeDesc)
+        assertThat(playTimeDesc.getContent())
             .extracting("title")
             .containsExactly(PREFIX + "quiz4", PREFIX + "quiz3", PREFIX + "quiz2", PREFIX + "quiz1");
-        assertThat(playTimeAsc)
+        assertThat(playTimeAsc.getContent())
             .extracting("title")
             .containsExactly(PREFIX + "quiz1", PREFIX + "quiz2", PREFIX + "quiz3", PREFIX + "quiz4");
 
@@ -88,18 +91,19 @@ class QuizRepositoryImplTest {
     public void recentSearchTest() {
         //given
         QuizSearchRepositoryCond condition = new QuizSearchRepositoryCond(PREFIX);
+        PageRequest pageRequest = PageRequest.of(0, 4);
         //when
-        List<QuizSearchRepositoryDto> recentDesc = quizRepositoryImpl.findRecentDesc(condition, 0, 4);
-        List<QuizSearchRepositoryDto> recentAsc = quizRepositoryImpl.findRecentAsc(condition, 0, 4);
+        Page<QuizSearchRepositoryDto> recentDesc = quizRepositoryImpl.findRecentDesc(condition, pageRequest);
+        Page<QuizSearchRepositoryDto> recentAsc = quizRepositoryImpl.findRecentAsc(condition, pageRequest);
 
         //퀴즈 생성 순서가 quiz1 -> quiz2 -> quiz3 -> quiz4 인것에 유의
         //then
-        assertThat(recentDesc)
+        assertThat(recentDesc.getContent())
             .extracting("title")
             .containsExactly(PREFIX + "quiz4", PREFIX + "quiz3", PREFIX + "quiz2", PREFIX + "quiz1");
-        assertThat(recentAsc)
-            .extracting("title")
-            .containsExactly(PREFIX + "quiz1", PREFIX + "quiz2", PREFIX + "quiz3", PREFIX + "quiz4");
+        assertThat(recentAsc.getContent())
+                .extracting("title")
+                .containsExactly(PREFIX + "quiz1", PREFIX + "quiz2", PREFIX + "quiz3", PREFIX + "quiz4");
 
     }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -18,6 +18,7 @@ spring.servlet.multipart.max-file-size=1MB
 spring.servlet.multipart.max-request-size=5MB
 
 file.thumbnail-image.path=${user.home}/harp-seal/thumbnail-image/
+file.thumbnail-image.default-path=${user.home}/harp-seal/thumbnail-image/default-image/default-image.png
 file.question-image.path=${user.home}/harp-seal/question/sound/
 file.question-sound.path=${user.home}/harp-seal/question/image/
 


### PR DESCRIPTION
## 단일 퀴즈 조회

퀴즈의 ID를 사용해서 단일 퀴즈에 대한 정보를 조회하는 기능입니다.

### 퀴즈 조회 URI
|메서드|URI|
|:--|:--|
|`GET`|`/api/v1/quiz/{quiz_id}`|


### 요청 데이터
- URI의 quiz_id
- 이전에 퀴즈의 목록을 요청했다면 응답 JSON에 퀴즈 ID정보가 포함되어있습니다. 퀴즈 ID정보를 활용하여 URI로 요청할 수 있습니다.

### 응답 데이터
해당하는 퀴즈 ID의 퀴즈 정보를 불러옵니다. 응답되는 JSON은 다음과 같습니다.

```json
{
    "quizId": 1,
    "title": "퀴즈 제목",
    "description": "퀴즈 설명",
    "thumbnailData": "썸네일 이미지 Base64 인코딩 데이터",
    "questions": [
        {
            "content": "문제 내용",
            "number": 1,
            "answer": "정답",
            "type": "문제 타입",
            "attachmentData": "첨부파일 Base64 인코딩 데이터",
            "choices": [
                {
                    "content": "선택지 1"
                },
                {
                    "content": "선택지 2"
                },
                {
                    "content": "선택지 3"
                }
            ]
        },
        {
            "content": "문제 내용",
            "number": 1,
            "answer": "문제 정답",
            "type": "문제 타입",
            "attachmentData": "첨부파일 Base64 인코딩 데이터",
            "choices": [
                {
                    "content": "선택지 1"
                },
                {
                    "content": "선택지 2"
                },
                {
                    "content": "선택지 3"
                }
            ]
        }
    ]
}
```
- `quizId`: 선택한 퀴즈의 ID
- `title`: 퀴즈 제목
- `description`: 퀴즈 설명
- `thumbnailData`: 퀴즈 썸네일 이미지 Base64 인코딩 데이터
- `questions`: 퀴즈 문제 데이터들
    - `content`: 퀴즈 내용
    - `number`: 문제 번호
    - `answer`: 문제 정답
    - `type`: 문제의 타입
        - `MULTIPLE`: 객관식
        - `SUBJECTIVE`: 주관식
    - `attachmentData`: 문제 첨부파일 데이터
    - `choices`: 선택지 데이터 목록
        - `content`: 선택지 내용